### PR TITLE
Modify project permission system

### DIFF
--- a/app/controllers/project_users_controller.rb
+++ b/app/controllers/project_users_controller.rb
@@ -11,6 +11,9 @@ class ProjectUsersController < ProjectsBaseController
 
   def destroy
     ProjectUser.find_by(user_id: params[:id], project: @current_project).destroy
+  rescue ProjectUser::LastRecordError => e
+    flash[:error] = e.message
+  ensure
     redirect_back(fallback_location: root_path)
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -23,6 +23,7 @@ class ProjectsController < ProjectsBaseController
       team: current_user.team,
       public_feed: params[:visibility] == 'Public'
     )
+    project.project_users.create(user_id: current_user.id)
 
     flash[:success] = 'Project created'
     return redirect_to dashboard_path

--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -1,4 +1,17 @@
 class ProjectUser < ApplicationRecord
+  class LastRecordError < StandardError; end
+
   belongs_to :project
   belongs_to :user
+  before_destroy :check_last_record
+
+  private
+
+  def check_last_record
+    raise LastRecordError.new("You cannot delete the last project user") if last_record?
+  end
+
+  def last_record?
+    project.project_users.count === 1
+  end
 end

--- a/app/src/projects_for_user.rb
+++ b/app/src/projects_for_user.rb
@@ -24,7 +24,6 @@ class ProjectsForUser
 
   def user_on_project?(project)
     users = project.project_users
-    return true if users.empty?
     return true if @user.super_user
     users.map(&:user_id).include? @user.id
   end

--- a/app/src/projects_for_user.rb
+++ b/app/src/projects_for_user.rb
@@ -23,8 +23,7 @@ class ProjectsForUser
   end
 
   def user_on_project?(project)
-    users = project.project_users
     return true if @user.super_user
-    users.map(&:user_id).include? @user.id
+    project.project_users.exists?(user_id: @user.id)
   end
 end

--- a/spec/models/project_user_spec.rb
+++ b/spec/models/project_user_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe ProjectUser, type: :model do
+  let(:user) {
+    create(:user, :with_team)
+  }
+  let(:project) {
+    create(:project, team: user.team)
+  }
+  let!(:project_user) {
+    ProjectUser.create(project_id: project.id, user_id: user.id)
+  }
+
+  describe '.destroy' do
+    subject { project_user.destroy }
+    context 'when it is the last record for the project' do
+      it 'cannot be deleted' do
+        expect {
+          subject
+        }.to raise_error(ProjectUser::LastRecordError, "You cannot delete the last project user")
+      end
+    end
+
+    context 'when it is not the last record for the project' do
+      before do
+        another_user = create(:user, team: user.team)
+        project.project_users.create(user_id: another_user.id)
+      end
+      it 'can be deleted' do
+        expect { subject }.to change { project.project_users.count }.by(-1)
+      end
+    end
+  end
+end

--- a/spec/src/user_permission_to_project_spec.rb
+++ b/spec/src/user_permission_to_project_spec.rb
@@ -52,8 +52,8 @@ RSpec.describe UserPermissionToProject do
     end
 
     context "when the project DOES NOT have a specific user list" do
-      it "returns true" do
-        expect(subject.run).to eq(true)
+      it "returns false" do
+        expect(subject.run).to eq(false)
       end
     end
   end


### PR DESCRIPTION
In the original implementation, a project is by default accessible by all members within the same team unless it has a specific user list (`project.project_users`). This is undesirable as it causes confusion among users within the same team.

This PR aims to remove this default behaviour by:
Remove the rule that a project without a specific allowlist should be accessible by all members of the same team.
Adding the current user to the project user list upon project creation so that she is accessible to the project.
Adding constraint prevents a user from deleting the entry from a project's user list when it is the last entry.
